### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/short_url/__init__.py
+++ b/short_url/__init__.py
@@ -93,7 +93,7 @@ class UrlEncoder(object):
     def enbase(self, x, min_length=MIN_LENGTH):
         result = self._enbase(x)
         padding = self.alphabet[0] * (min_length - len(result))
-        return '%s%s' % (padding, result)
+        return '{0!s}{1!s}'.format(padding, result)
 
     def _enbase(self, x):
         n = len(self.alphabet)

--- a/tests/test_short_url.py
+++ b/tests/test_short_url.py
@@ -26,7 +26,7 @@ def generate_test_data(count=10000):
 
     with open(os.path.join(TEST_DATA, 'key_values.txt'), 'w') as f:
         for k, v in result.items():
-            f.write('%s:%s\n' % (k, v))
+            f.write('{0!s}:{1!s}\n'.format(k, v))
 
 # generate_test_data()
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:sachinr-test:python-short_url?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:sachinr-test:python-short_url?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
